### PR TITLE
Keep songs in a sorted map data-structure

### DIFF
--- a/src/cljc/channel/utils.cljc
+++ b/src/cljc/channel/utils.cljc
@@ -18,6 +18,15 @@
     (when-not (and (seq args) (any-nil? args))
       (apply f args))))
 
+(defn map->sorted-map
+  "Converts a hash-map `m` to a sorted hash-map using `compfn` to
+  compare the values of `m`."
+  [compfn m]
+  (let [sorter (fn [k1 k2]
+                 (compare (compfn (get m k1))
+                          (compfn (get m k2))))]
+    (into (sorted-map-by sorter) m)))
+
 ;;
 ;; Async
 ;;

--- a/src/cljs/channel/core.cljs
+++ b/src/cljs/channel/core.cljs
@@ -2,13 +2,8 @@
   (:require [ajax.core :refer [GET]]
             [channel.db :refer [app-state]]
             [channel.views.core :as views]
+            [channel.utils :refer [map->sorted-map]]
             [rum.core :as rum]))
-
-(defn sorted-map-from-map [keyfn m]
-  (let [sorter (fn [k1 k2]
-                 (compare (keyfn (get m k1))
-                          (keyfn (get m k2))))]
-    (into (sorted-map-by sorter) m)))
 
 (defn mount! []
   (rum/mount
@@ -21,5 +16,5 @@
   (GET "/api/songs" {:handler #(->> %
                                     (reduce (fn [acc {:keys [id] :as s}]
                                               (assoc acc id s)) {})
-                                    (sorted-map-from-map (juxt :artist :album :track))
+                                    (map->sorted-map (juxt :artist :album :track))
                                     (swap! app-state assoc :songs))}))

--- a/src/cljs/channel/core.cljs
+++ b/src/cljs/channel/core.cljs
@@ -4,6 +4,12 @@
             [channel.views.core :as views]
             [rum.core :as rum]))
 
+(defn sorted-map-from-map [keyfn m]
+  (let [sorter (fn [k1 k2]
+                 (compare (keyfn (get m k1))
+                          (keyfn (get m k2))))]
+    (into (sorted-map-by sorter) m)))
+
 (defn mount! []
   (rum/mount
    (views/main-page app-state)
@@ -15,4 +21,5 @@
   (GET "/api/songs" {:handler #(->> %
                                     (reduce (fn [acc {:keys [id] :as s}]
                                               (assoc acc id s)) {})
+                                    (sorted-map-from-map (juxt :artist :album :track))
                                     (swap! app-state assoc :songs))}))

--- a/src/cljs/channel/views/songs.cljs
+++ b/src/cljs/channel/views/songs.cljs
@@ -5,25 +5,24 @@
 
 (rum/defc songs-page < rum/reactive
   [db]
-  (let [songs (vals (:songs (rum/react db)))]
-    [:.row
-     [:.col-lg-12
-      [:table.table.table-striped
-       [:thead
+  [:.row
+   [:.col-lg-12
+    [:table.table.table-striped
+     [:thead
+      [:tr
+       [:th "#"]
+       [:th "Title"]
+       [:th "Artist"]
+       [:th "Album"]
+       [:th {:col-span 2}]]]
+     [:tbody
+      (for [s (vals (:songs (rum/react db)))]
         [:tr
-         [:th "#"]
-         [:th "Title"]
-         [:th "Artist"]
-         [:th "Album"]
-         [:th {:col-span 2}]]]
-       [:tbody
-        (for [s (sort-by (juxt :artist :album :track) songs)]
-          [:tr
-           {:key (:id s)}
-           [:th (:track s)]
-           [:td (:title s)]
-           [:td (:artist s)]
-           [:td (:album s)]
-           [:td [:button {:on-click
-                          #(events/dispatch! [:songs/play s])}
-                 [:i.fa.fa-play]]]])]]]]))
+         {:key (:id s)}
+         [:th (:track s)]
+         [:td (:title s)]
+         [:td (:artist s)]
+         [:td (:album s)]
+         [:td [:button {:on-click
+                        #(events/dispatch! [:songs/play s])}
+               [:i.fa.fa-play]]]])]]]])

--- a/test/clj/channel/test/utils.clj
+++ b/test/clj/channel/test/utils.clj
@@ -27,3 +27,20 @@
   (let [f (maybe (fn [& _] :called))]
     (testing "calls function if there are no parameters"
       (is (= (f) :called)))))
+
+(deftest sorted-map-by-value
+  (testing "with a nested map"
+    (testing "single key"
+      (let [m {1 {:priority 5}, 2 {:priority 3}, 3 {:priority 10}}]
+        (is (= (map->sorted-map :priority m)
+               {2 {:priority 3}, 1 {:priority 5}, 3 {:priority 10}}))))
+    (testing "multiple keys with priority"
+      (let [m {1 {:track 1, :artist "Black Sabbath", :album "Black Sabbath"}
+               2 {:track 3, :artist "Black Sabbath", :album "Paranoid"}
+               3 {:track 1, :artist "Black Sabbath", :album "Paranoid"}
+               4 {:track 2, :artist "Black Sabbath", :album "Black Sabbath"}}]
+        (is (= (map->sorted-map (juxt :artist :album :track) m)
+               {1 {:track 1, :artist "Black Sabbath", :album "Black Sabbath"}
+                4 {:track 2, :artist "Black Sabbath", :album "Black Sabbath"}
+                3 {:track 1, :artist "Black Sabbath", :album "Paranoid"}
+                2 {:track 3, :artist "Black Sabbath", :album "Paranoid"}}))))))


### PR DESCRIPTION
Songs are now sorted inside of a sorted `PersistentTreeMap` rather than just when shown in the view. This allows the play queue to have the same order as the one that the user sees.